### PR TITLE
Parse boolean strings from .env file or env vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,4 @@
 overridden=from .env
+bool1=TRUE
+bool2=true
+bool3=false

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ function expandPath(name) {
 
 function setConfig(name, value) {
   var expanded = expandPath(name);
+  if (/^(true|false)$/i.test(value)) value = (value.toLowerCase() === "true");
   expanded.current[expanded.last] = value;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "exp-config",
   "description": "Simple configuration management",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "AB Kvällstidningen Expressen",
   "contributors": [
     "Gabriel Falkenberg <gabriel.falkenberg@gmail.com>",

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,13 @@ describe("config", function() {
     require("../index").should.have.property("overridden").equal("from .env");
   });
 
+  it("parses boolean values from .env file", function() {
+    var config = require("../index");
+    config.should.have.property("bool1").equal(true);
+    config.should.have.property("bool2").equal(true);
+    config.should.have.property("bool3").equal(false);
+  });
+
   it("retrives values from .env files from <app root>", function() {
     require("../tmp/index").should.have.property("overridden").equal("from .env");
   });
@@ -46,6 +53,13 @@ describe("config", function() {
     config = require("../index");
     config.should.have.property("overridden").equal("from test.json");
     delete process.env.NODE_ENV;
+  });
+
+  it("parses boolean values from environment variables", function() {
+    process.env.BOOL_TEST = "true";
+    var config = require("../index");
+    config.should.have.property("BOOL_TEST").equal(true);
+    delete process.env.BOOL_TEST;
   });
 
   it("supports overriding values with environment variables", function() {


### PR DESCRIPTION
Boolean values from the .env file or environment variables were saved as their string values, "true" and "false". I added a check that parses them into bools.

This is a not completely backwards compatible change, thus the minor version is bumped.