### PR TITLE
Use env variables in test

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ In other words, environment variables take precedence over `.env` files and conf
 
 _NOTE, there is one exception_: When `NODE_ENV` equals `test` (`NODE_ENV=test`) `.env` files are ignored. Otherwise this file likely would have to be edited every time `npm test` is invoked.
 
+_NOTE II, exception to the excpetion_: If you want your .env file and environment variables to be honored in the `test` environment, you can set the `ALLOW_ENV_OVERRIDE` environment variable. 
+
+
 ## Specifying the root folder
 
 By default `exp-config` tries to locate the config folder and the (optional) `.env` file by using `process.cwd()`. This works great when starting the application from it's root folder. However, sometimes that's not possible. In such cases the root path can be specified by setting an environment variable named `CONFIG_BASE_PATH`, like this:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Values are loaded with the following precedence:
 2. .env file
 3. Configuration file
 
-In other words, environment variables take precedence over `.env` files and configuration files. However, there is one exception. When `NODE_ENV` equals `test` (`NODE_ENV=test`) environment variables and `.env` files are ignored.
+In other words, environment variables take precedence over `.env` files and configuration files.
+
+_NOTE, there is one exception_: When `NODE_ENV` equals `test` (`NODE_ENV=test`) `.env` files are ignored. Otherwise this file likely would have to be edited every time `npm test` is invoked.
 
 ## Specifying the root folder
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function setConfig(name, value) {
 
 config = applyDefault(config);
 
-if (envName !== "test") {
+if (envName !== "test" || process.env.ALLOW_TEST_ENV_OVERRIDE) {
   // Config from .env file have precedence over environment json config
   var dotenvPath = path.join(basePath, ".env");
   if (fs.existsSync(dotenvPath)) {

--- a/test/test.js
+++ b/test/test.js
@@ -55,6 +55,16 @@ describe("config", function() {
     delete process.env.NODE_ENV;
   });
 
+  it("uses values from .env when NODE_ENV=test if ALLOW_TEST_ENV_OVERRIDE is set", function() {
+    process.env.NODE_ENV = "test";
+    process.env.ALLOW_TEST_ENV_OVERRIDE = "true";
+    var config = require("../index");
+    config = require("../index");
+    config.should.have.property("overridden").equal("from .env");
+    delete process.env.NODE_ENV;
+    delete process.env.ALLOW_TEST_ENV_OVERRIDE;
+  });
+
   it("parses boolean values from environment variables", function() {
     process.env.BOOL_TEST = "true";
     var config = require("../index");
@@ -80,6 +90,17 @@ describe("config", function() {
     delete process.env.NODE_ENV;
     delete process.env.overridden;
   });
+
+  it("uses environment variables when NODE_ENV=test if ALLOW_TEST_ENV_OVERRIDE is set", function() {
+    process.env.NODE_ENV = "test";
+    process.env.ALLOW_TEST_ENV_OVERRIDE = "true";
+    process.env.overridden = "from environment variable";
+    require("../index").should.have.property("overridden").equal("from environment variable");
+    delete process.env.NODE_ENV;
+    delete process.env.ALLOW_TEST_ENV_OVERRIDE;
+    delete process.env.overridden;
+  });
+  
 
   it("supports reading config from a custom base path", function() {
     process.env.CONFIG_BASE_PATH = path.join(__dirname, "../tmp/");


### PR DESCRIPTION
Very useful to set environment variables when running tests in a docker
container.