### PR TITLE
Feature/replace dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ _NOTE, there is one exception_: When `NODE_ENV` equals `test` (`NODE_ENV=test`) 
 
 _NOTE II, exception to the exception_: If you want environment variables to be honored in the `test` environment, you can set the `ALLOW_TEST_ENV_OVERRIDE` environment variable. This is useful for overriding certain configurations when doing in-container testing. The `.env` file will still be ignored however.
 
+### When periods are not allowed in environment variables
+
+In openshift and some versions of alpine, you are not allowed to set environvariables with periods (".") in them. To solve this exp-config allows you to set `INTERPRET_CHAR_AS_DOT` to any char you like to be interpret as a period. Setting `INTERPRET_CHAR_AS_DOT=_` and `foo_baz_bar="value"` will set the value `foo.baz.bar` to `"value"` as long as `foo.baz.bar` it exists in the config-file.
+
 
 ## Specifying the root folder
 

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,11 @@
 {
   "prop": "default",
   "newProp": true,
-  "overridden": "from default.json"
+  "overridden": "from default.json",
+  "nested": {
+  	"prop": true,
+  	"nested": {
+  		"prop": false
+  	}
+  }
 }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const merge = require("lodash.merge");
 const envName = process.env.NODE_ENV || "development";
 const basePath = process.env.CONFIG_BASE_PATH || process.cwd();
 const prefix = process.env.ENV_PREFIX;
-const charToConvert = process.env.CONVERT_CHAR_TO_DOTS;
+const charToConvert = process.env.INTERPRET_CHAR_AS_DOT;
 let defaultConfig = {};
 let config = require(path.join(basePath, "config", envName));
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const merge = require("lodash.merge");
 const envName = process.env.NODE_ENV || "development";
 const basePath = process.env.CONFIG_BASE_PATH || process.cwd();
 const prefix = process.env.ENV_PREFIX;
+const charToConvert = process.env.CONVERT_CHAR_TO_DOTS;
 let defaultConfig = {};
 let config = require(path.join(basePath, "config", envName));
 
@@ -57,10 +58,31 @@ if (envName !== "test") {
 if (envName !== "test" || process.env.ALLOW_TEST_ENV_OVERRIDE) {
   // Real env vars should have precedence over .env
   Object.keys(process.env).forEach((key) => {
-    const envKey = prefix ? key.replace(prefix, "") : key;
-    setConfig(envKey, process.env[key]);
+    setConfig(convertKey(key), process.env[key]);
   });
 }
+
+function convertKey(key) {
+    const envKey = prefix ? key.replace(prefix, "") : key;
+    const replacedEnvKey = charToConvert ? envKey.replace(new RegExp(charToConvert, "g"), ".") : envKey;
+    if (existsInConfig(replacedEnvKey)) {
+      return replacedEnvKey;
+    }
+    return envKey;
+}
+
+function existsInConfig(key) {
+    const parts = key.split(".");
+    let current = config;
+    const last = parts.pop();
+    parts.forEach((part) => {
+      if (current.hasOwnProperty(part)) {
+        current = current[part];
+      }
+    });
+    return current.hasOwnProperty(last);
+}
+
 
 config.envName = envName;
 

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ if (envName !== "test" || process.env.ALLOW_TEST_ENV_OVERRIDE) {
 function convertKey(key) {
     const envKey = prefix ? key.replace(prefix, "") : key;
     const replacedEnvKey = charToConvert ? envKey.replace(new RegExp(charToConvert, "g"), ".") : envKey;
-    if (existsInConfig(replacedEnvKey)) {
+    if (existsInConfig(replacedEnvKey) && !process.env[replacedEnvKey]) {
       return replacedEnvKey;
     }
     return envKey;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "exp-config",
   "description": "Simple configuration management",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "AB Kvällstidningen Expressen",
   "contributors": [
     "Gabriel Falkenberg <gabriel.falkenberg@gmail.com>",

--- a/test/test.js
+++ b/test/test.js
@@ -159,6 +159,62 @@ describe("config", () => {
     delete process.env.ENV_PREFIX;
   });
 
+  describe("replace token from bash variable", () => {
+    afterEach(() => {
+      delete process.env.CONVERT_CHAR_TO_DOTS;
+      delete process.env.nested_prop;
+      delete process.env.NODE_ENV;
+      delete process.env.ALLOW_TEST_ENV_OVERRIDE;
+      delete process.env.MY_ENV_nested_prop; // jshint ignore:line
+      delete process.env.ENV_PREFIX;
+    });
+
+    it("should replace dots the given char in CONVERT_CHAR_TO_DOTS", () => {
+      process.env.CONVERT_CHAR_TO_DOTS = "_";
+      process.env.nested_prop = "from environment variable"; //eslint-disable-line camelcase
+      const conf = require("../index");
+      conf.nested.prop.should.eql("from environment variable");
+      conf.should.not.have.property("nested_prop").equal("from environment variable");
+    });
+
+    it("should replace dots the given char in CONVERT_CHAR_TO_DOTS multiple times", () => {
+      process.env.CONVERT_CHAR_TO_DOTS = "_";
+      process.env.nested_nested_prop = "from environment variable"; //eslint-disable-line camelcase
+      const conf = require("../index");
+      conf.nested.nested.prop.should.eql("from environment variable");
+      conf.should.not.have.property("nested_nested_prop").equal("from environment variable");
+    });
+
+
+    it("should not replace variables in config file", () => {
+      process.env.CONVERT_CHAR_TO_DOTS = "_";
+      const conf = require("../index");
+      conf.should.not.have.property("nested_prop");
+      conf.nested.prop.should.eql(true);
+    });
+
+    it("should replace variables after ENV_PREFIX", () => {
+      process.env.CONVERT_CHAR_TO_DOTS = "_";
+      process.env.ENV_PREFIX = "MY_ENV_";
+      process.env.ALLOW_TEST_ENV_OVERRIDE = "true";
+      process.env.MY_ENV_nested_prop = "from environment variable"; //eslint-disable-line camelcase
+      const conf = require("../index");
+      conf.nested.prop.should.eql("from environment variable");
+      conf.should.not.have.property("MY_ENV_nested_prop").equal("from environment variable");
+      conf.should.not.have.property("nested_prop").equal("from environment variable");
+    });
+
+    it("should only replace values that exists in config file", () => {
+      process.env.CONVERT_CHAR_TO_DOTS = "_";
+      process.env.nested_prop2 = "from environment variable"; //eslint-disable-line camelcase
+      const conf = require("../index");
+      conf.nested.should.not.have.property("prop2").equal("from environment variable");
+      conf.should.have.property("nested_prop2").equal("from environment variable");
+    });
+
+    // TODO: race condition for . and _
+  });
+
   describe("config files in .js", () => {
     before(() => {
       process.env.NODE_ENV = "livedata";

--- a/test/test.js
+++ b/test/test.js
@@ -161,7 +161,7 @@ describe("config", () => {
 
   describe("replace token from bash variable", () => {
     afterEach(() => {
-      delete process.env.CONVERT_CHAR_TO_DOTS;
+      delete process.env.INTERPRET_CHAR_AS_DOT;
       delete process.env.nested_prop;
       delete process.env.NODE_ENV;
       delete process.env.ALLOW_TEST_ENV_OVERRIDE;
@@ -170,16 +170,16 @@ describe("config", () => {
       delete process.env.nested_prop2;
     });
 
-    it("should replace dots the given char in CONVERT_CHAR_TO_DOTS", () => {
-      process.env.CONVERT_CHAR_TO_DOTS = "_";
+    it("should replace dots the given char in INTERPRET_CHAR_AS_DOT", () => {
+      process.env.INTERPRET_CHAR_AS_DOT = "_";
       process.env.nested_prop = "from environment variable"; //eslint-disable-line camelcase
       const conf = require("../index");
       conf.nested.prop.should.eql("from environment variable");
       conf.should.not.have.property("nested_prop").equal("from environment variable");
     });
 
-    it("should replace dots the given char in CONVERT_CHAR_TO_DOTS multiple times", () => {
-      process.env.CONVERT_CHAR_TO_DOTS = "_";
+    it("should replace dots the given char in INTERPRET_CHAR_AS_DOT multiple times", () => {
+      process.env.INTERPRET_CHAR_AS_DOT = "_";
       process.env.nested_nested_prop = "from environment variable"; //eslint-disable-line camelcase
       const conf = require("../index");
       conf.nested.nested.prop.should.eql("from environment variable");
@@ -188,14 +188,14 @@ describe("config", () => {
 
 
     it("should not replace variables in config file", () => {
-      process.env.CONVERT_CHAR_TO_DOTS = "_";
+      process.env.INTERPRET_CHAR_AS_DOT = "_";
       const conf = require("../index");
       conf.should.not.have.property("nested_prop");
       conf.nested.prop.should.eql(true);
     });
 
     it("should replace variables after ENV_PREFIX", () => {
-      process.env.CONVERT_CHAR_TO_DOTS = "_";
+      process.env.INTERPRET_CHAR_AS_DOT = "_";
       process.env.ENV_PREFIX = "MY_ENV_";
       process.env.ALLOW_TEST_ENV_OVERRIDE = "true";
       process.env.MY_ENV_nested_prop = "from environment variable"; //eslint-disable-line camelcase
@@ -206,17 +206,17 @@ describe("config", () => {
     });
 
     it("should only replace values that exists in config file", () => {
-      process.env.CONVERT_CHAR_TO_DOTS = "_";
+      process.env.INTERPRET_CHAR_AS_DOT = "_";
       process.env.nested_prop2 = "from environment variable"; //eslint-disable-line camelcase
       const conf = require("../index");
       conf.nested.should.not.have.property("prop2").equal("from environment variable");
       conf.should.have.property("nested_prop2").equal("from environment variable");
     });
 
-    it("dots should have precedence over CONVERT_CHAR_TO_DOTS", () => {
-      process.env.CONVERT_CHAR_TO_DOTS = "_";
+    it("dots should have precedence over INTERPRET_CHAR_AS_DOT", () => {
+      process.env.INTERPRET_CHAR_AS_DOT = "_";
       process.env["nested.prop"] = "baz";
-      process.env["nested_prop"] = "foo";
+      process.env.nested_prop = "foo"; //eslint-disable-line camelcase
       const conf = require("../index");
       conf.nested.prop.should.equal("baz");
     });

--- a/test/test.js
+++ b/test/test.js
@@ -167,6 +167,7 @@ describe("config", () => {
       delete process.env.ALLOW_TEST_ENV_OVERRIDE;
       delete process.env.MY_ENV_nested_prop; // jshint ignore:line
       delete process.env.ENV_PREFIX;
+      delete process.env.nested_prop2;
     });
 
     it("should replace dots the given char in CONVERT_CHAR_TO_DOTS", () => {
@@ -212,7 +213,13 @@ describe("config", () => {
       conf.should.have.property("nested_prop2").equal("from environment variable");
     });
 
-    // TODO: race condition for . and _
+    it("dots should have precedence over CONVERT_CHAR_TO_DOTS", () => {
+      process.env.CONVERT_CHAR_TO_DOTS = "_";
+      process.env["nested.prop"] = "baz";
+      process.env["nested_prop"] = "foo";
+      const conf = require("../index");
+      conf.nested.prop.should.equal("baz");
+    });
   });
 
   describe("config files in .js", () => {


### PR DESCRIPTION
In openshift and some versions of alpine  period (".") is not allowed as bash env variables. This solves this problem by iterpreting any char (as given in INTERPRET_CHAR_AS_DOT env variable)  in bash env variable as a period.